### PR TITLE
Totally refactored the contact#modal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,4 +16,7 @@
 # Ignore all logfiles and tempfiles.
 /log/*.log
 /tmp
-/cold_callr-ember/node_modules/*
+cold_callr-ember/dist
+cold_callr-ember/node_modules
+cold_callr-ember/tmp
+cold_callr-ember/bower_components

--- a/cold_callr-ember/app/routes/contacts.js
+++ b/cold_callr-ember/app/routes/contacts.js
@@ -16,6 +16,14 @@ export default Ember.Route.extend(PaginationRouteMixin,{
 
   model: function(params) {
     return this.store.find('contact', {page: params.page, sort_by: params.sortBy, status: params.status, query: params.query});
-  }
+  },
 
+  //TODO: refactor to use https://github.com/simplabs/ember-simple-auth#readme
+    actions: {
+        error: function (error, transition) {
+            if (error && error.status === 401 && error.statusText === "Unauthorized") {
+                window.location.href = window.location.origin + "/users/sign_in"
+            }
+        }
+    }
 });

--- a/cold_callr-ember/app/templates/contacts/show.hbs
+++ b/cold_callr-ember/app/templates/contacts/show.hbs
@@ -7,44 +7,32 @@
                     <div class="col-xs-12">
                         {{#if isNexting}}
                             <div class="row">
-                                <div class="col-xs-12 col-sm-4 col-md-6">
+                                <div class="col-xs-12 col-sm-4">
                                     {{#link-to 'contacts' (query-params status="" page=1 query='') class='btn btn-default'}}
                                         Close
                                     {{/link-to}}
                                 </div>
-                                <div class="col-xs-12 col-sm-8 col-md-6">
-                                    <div class="btn-group btn-group-justified" role="group">
-                                        <div class="btn-group">
-                                            <button type="button"  {{action "getNext" model 'Left Message'}}
-                                                    class="btn btn-success">
-                                                Left Message
-                                            </button>
-                                        </div>
-                                        <div class="btn-group">
-                                            <button type="button"  {{action "getNext" model 'Do Not Call'}}
-                                                    class="btn btn-danger">
-                                                Do Not Call
-                                            </button>
-                                        </div>
-                                        <div class="btn-group">
-                                            <button type="button"  {{action "getNext" model 'Call Back'}}
-                                                    class="btn btn-info">
-                                                Call Back
-                                            </button>
-                                        </div>
-                                        <div class="btn-group">
-                                            <button type="button"  {{action "getNext" model 'Wrong Number'}}
-                                                    class="btn btn-warning">
-                                                Wrong Number
-                                            </button>
-                                        </div>
-                                        <div class="btn-group">
-                                            <button type="button"  {{action "getNext" model 'Success'}}
-                                                    class="btn btn-success">
-                                                Success
-                                            </button>
-                                        </div>
-                                    </div>
+                                <div class="col-xs-12 col-sm-8 text-right">
+                                    <button type="button"  {{action "getNext" model 'Left Message'}}
+                                            class="btn btn-success">
+                                        Left Message
+                                    </button>
+                                    <button type="button"  {{action "getNext" model 'Do Not Call'}}
+                                            class="btn btn-danger">
+                                        Do Not Call
+                                    </button>
+                                    <button type="button"  {{action "getNext" model 'Call Back'}}
+                                            class="btn btn-info">
+                                        Call Back
+                                    </button>
+                                    <button type="button"  {{action "getNext" model 'Wrong Number'}}
+                                            class="btn btn-warning">
+                                        Wrong Number
+                                    </button>
+                                    <button type="button"  {{action "getNext" model 'Success'}}
+                                            class="btn btn-success">
+                                        Success
+                                    </button>
                                 </div>
                             </div>
                         {{else}}
@@ -62,7 +50,7 @@
                                             <div class="col-xs-5"><span class="lead">{{name}}</span></div>
                                             <div class="col-xs-7">
                                                 <a class="btn btn-success"
-                                                                     target="_blank" {{bind-attr href="phoneLink"}}">
+                                                   target="_blank" {{bind-attr href="phoneLink"}}">
                                                 Call: {{number-to-phone phone}}
                                                 </a>
                                             </div>
@@ -103,7 +91,8 @@
                                                         {{textarea value=newNoteBody id='body' class="form-control" placeholder="New Note" rows=4}}
                                                     </div>
                                                     <div class="form-group">
-                                                        <button class="btn btn-primary btn-block col-xs-6" type="submit">Add Note
+                                                        <button class="btn btn-primary btn-block col-xs-6"
+                                                                type="submit">Add Note
                                                         </button>
                                                     </div>
                                                 </form>
@@ -114,12 +103,12 @@
                                         <ul class="list-group">
                                             <li class="list-group-item disabled">Admin Notes</li>
                                             {{#each sortedActivities}}
-                                                <li class="list-group-item"><strong>{{userName}}</strong> {{createdAt}} {{notes}}</li>
+                                                <li class="list-group-item">
+                                                    <strong>{{userName}}</strong> {{createdAt}} {{notes}}</li>
                                             {{/each}}
                                         </ul>
                                     {{/if}}
                                 </div>
-
 
 
                             </div>

--- a/cold_callr-ember/app/templates/contacts/show.hbs
+++ b/cold_callr-ember/app/templates/contacts/show.hbs
@@ -3,106 +3,130 @@
         <div class="modal-content">
             <div class="modal-body">
                 <!--modal body start-->
-                <div class="jumbotron">
-                    <div class="row">
-
-                        <div class="col-xs-12 text-right">
-                          {{#if isNexting}}
-                              <div class="row">
-                                  <div class="col-sm-1">
-                                    {{#link-to 'contacts' (query-params status="" page=1 query='') class='btn btn-default'}}Close{{/link-to}}
-                                  </div>
-                                  <div class="col-sm-3 text-right">Status:</div>
-                                  <div class="col-sm-8 text-right">
-                                      <div class="btn-group">
-                                          <button {{action "getNext" model 'Left Message'}} class="btn btn-success">Left Message</button>
-                                          <button {{action "getNext" model 'Do Not Call'}} class="btn btn-danger">Do Not Call</button>
-                                          <button {{action "getNext" model 'Call Back'}} class="btn btn-info">Call Back</button>
-                                          <button {{action "getNext" model 'Wrong Number'}} class="btn btn-warning">Wrong Number</button>
-                                          <button {{action "getNext" model 'Success'}} class="btn btn-success">Success</button>
-
-                                      </div>
-                                  </div>
-                              </div>
-
-
-                          {{else}}
-                              <button {{action "nextClick"}} class="btn btn-success">Next</button>
-                          {{/if}}
-
-                        </div>
-                    </div>
-                    <div class="row">
-                        <div class="col-xs-8">
-                            <h3>{{name}}</h3>
-                            <ul class="lead">
-                              {{#each property in formattedProperties}}
-                                  <li>{{property.key}}: {{property.value}}</li>
-                              {{/each}}
-                            </ul>
+                <div class="row mbl">
+                    <div class="col-xs-12">
+                        {{#if isNexting}}
                             <div class="row">
-                                <div class="col-lg-12">
-                                    <a class="btn btn-lg btn-success" target="_blank" {{bind-attr href="phoneLink"}}" role="button">Call: {{number-to-phone phone}}</a>
-
+                                <div class="col-xs-12 col-sm-4 col-md-6">
+                                    {{#link-to 'contacts' (query-params status="" page=1 query='') class='btn btn-default'}}
+                                        Close
+                                    {{/link-to}}
+                                </div>
+                                <div class="col-xs-12 col-sm-8 col-md-6">
+                                    <div class="btn-group btn-group-justified" role="group">
+                                        <div class="btn-group">
+                                            <button type="button"  {{action "getNext" model 'Left Message'}}
+                                                    class="btn btn-success">
+                                                Left Message
+                                            </button>
+                                        </div>
+                                        <div class="btn-group">
+                                            <button type="button"  {{action "getNext" model 'Do Not Call'}}
+                                                    class="btn btn-danger">
+                                                Do Not Call
+                                            </button>
+                                        </div>
+                                        <div class="btn-group">
+                                            <button type="button"  {{action "getNext" model 'Call Back'}}
+                                                    class="btn btn-info">
+                                                Call Back
+                                            </button>
+                                        </div>
+                                        <div class="btn-group">
+                                            <button type="button"  {{action "getNext" model 'Wrong Number'}}
+                                                    class="btn btn-warning">
+                                                Wrong Number
+                                            </button>
+                                        </div>
+                                        <div class="btn-group">
+                                            <button type="button"  {{action "getNext" model 'Success'}}
+                                                    class="btn btn-success">
+                                                Success
+                                            </button>
+                                        </div>
+                                    </div>
                                 </div>
                             </div>
-
-                            <div class="row mtm" style="margin-top: 10px;">
-                                <div class="col-lg-12">
-                                    Status: {{inline-dropdown value=status model=model options=controller.statusOptions attribute="status"}}
-
-                                </div>
-                            </div>
-
-                        </div>
-                        <div class="col-xs-4 panel" style='margin-top: 100px;'>
-                            <p>Existing Contacts:</p>
-                            <ul>
-                              {{#each externalContact in externalContacts}}
-                                  <li>{{externalContact.name}} {{external-more contact=externalContact}}</li>
-                              {{/each}}
-                            </ul>
-                        </div>
+                        {{else}}
+                            <button {{action "nextClick"}} class="btn btn-success">Next</button>
+                        {{/if}}
                     </div>
-
-                    <div style="height: 20px;"></div>
-
-
-                    <div class="row">
-                        <div class="col-lg-6">
-                            <div class="panel panel-default">
-
-                                <div class="panel-heading">Admin Notes</div>
-                                <div class="panel-body">
-
-                                    <ul class="list-unstyled">
-                                      {{#each sortedActivities}}
-                                          <li><strong>{{userName}}</strong> {{createdAt}} {{notes}}</li>
-                                      {{/each}}
-                                    </ul>
-                                </div>
-                            </div>
-                        </div>
-                        <div class="col-lg-6">
-                            <div class="panel panel-default">
-                                <div class="panel-heading">New Note</div>
-                                <div class="panel-body">
-                                    <form {{action "newAdminNote" on="submit"}}>
-                                        <div class="form-group row">
-                                            <div class="col-sm-9">
-                                              {{textarea value=newNoteBody id='body' class="form-control" placeholder="New Note" rows=4}}
-                                            </div>
-                                            <div class="col-sm-3">
-                                                <button class="btn btn-primary btn-block" type="submit">Add Note</button>
+                </div>
+                <div class="row">
+                    <div class="col-xs-12">
+                        <div class="row">
+                            <div class="col-xs-12 col-sm-4">
+                                <div class="panel panel-default">
+                                    <div class="panel-heading">
+                                        <div class="row">
+                                            <div class="col-xs-5"><span class="lead">{{name}}</span></div>
+                                            <div class="col-xs-7">
+                                                <a class="btn btn-success"
+                                                                     target="_blank" {{bind-attr href="phoneLink"}}">
+                                                Call: {{number-to-phone phone}}
+                                                </a>
                                             </div>
                                         </div>
-                                    </form>
+                                    </div>
+                                    <div class="panel-body">
+                                        <ul class="list-unstyled">
+                                            <li>
+                                                Status: {{inline-dropdown value=status model=model options=controller.statusOptions attribute="status"}}
+                                            </li>
+                                            {{#each property in formattedProperties}}
+                                                <li>{{property.key}}: {{property.value}}</li>
+                                            {{/each}}
+                                        </ul>
+                                    </div>
                                 </div>
+                            </div>
+                            <div class="col-xs-12 col-sm-4">
+                                <div class="panel panel-default">
+                                    <div class="panel-heading">Existing Contacts:</div>
+                                    <div class="panel-body">
+                                        <ul class="list-group">
+                                            {{#each externalContact in externalContacts}}
+                                                <li class="list-group-item">{{externalContact.name}} {{external-more contact=externalContact}}</li>
+                                            {{/each}}
+                                        </ul>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="col-xs-12 col-sm-4">
+                                <div class="panel panel-default">
+                                    <div class="panel-heading">New Note</div>
+                                    <div class="panel-body">
+                                        <div class="row">
+                                            <div class="col-xs-12 mbs">
+                                                <form {{action "newAdminNote" on="submit"}}>
+                                                    <div class="form-group">
+                                                        {{textarea value=newNoteBody id='body' class="form-control" placeholder="New Note" rows=4}}
+                                                    </div>
+                                                    <div class="form-group">
+                                                        <button class="btn btn-primary btn-block col-xs-6" type="submit">Add Note
+                                                        </button>
+                                                    </div>
+                                                </form>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    {{#if sortedActivities}}
+                                        <ul class="list-group">
+                                            <li class="list-group-item disabled">Admin Notes</li>
+                                            {{#each sortedActivities}}
+                                                <li class="list-group-item"><strong>{{userName}}</strong> {{createdAt}} {{notes}}</li>
+                                            {{/each}}
+                                        </ul>
+                                    {{/if}}
+                                </div>
+
+
+
                             </div>
                         </div>
                     </div>
-
                 </div>
+
                 <!--end the modal body-->
             </div>
         </div>


### PR DESCRIPTION
### what does this do

- refactors bootstrap styles on the contact#show(modal)
- if a contact#index API request returns an error then it redirects to `users/sign_in`

### screenshot

![screen shot 2015-01-19 at 4 28 28 pm](https://cloud.githubusercontent.com/assets/955736/5810273/7c6b7452-9ff8-11e4-8fb8-2a30f57ccd1e.png)
